### PR TITLE
Deprecate set-output command

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
         id: generate-colored-output
         run: |
           colored=$(printf '\e[0;31mCOLORED\e[0m')
-          echo "{colored}={$colored}" >> "$GITHUB_OUTPUT"
+          echo "colored=$colored" >> "$GITHUB_OUTPUT"
       - name: Assert ANSI color escape sequences present in input string
         run: |
           if [[ "${{ steps.generate-colored-output.outputs.colored }}" != $(printf '\e[0;31mCOLORED\e[0m') ]]; then

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
         id: generate-colored-output
         run: |
           colored=$(printf '\e[0;31mCOLORED\e[0m')
-          echo "{colored}={$colored}" >> "$GITHUB_ENV"
+          echo "{colored}={$colored}" >> "$GITHUB_OUTPUT"
       - name: Assert ANSI color escape sequences present in input string
         run: |
           if [[ "${{ steps.generate-colored-output.outputs.colored }}" != $(printf '\e[0;31mCOLORED\e[0m') ]]; then

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
         id: generate-colored-output
         run: |
           colored=$(printf '\e[0;31mCOLORED\e[0m')
-          echo "::set-output name=colored::$colored"
+          echo "{colored}={$colored}" >> "$GITHUB_ENV"
       - name: Assert ANSI color escape sequences present in input string
         run: |
           if [[ "${{ steps.generate-colored-output.outputs.colored }}" != $(printf '\e[0;31mCOLORED\e[0m') ]]; then

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ jobs:
         id: generate-colored-output
         run: |
           colored=$(printf '\e[0;31mCOLORED\e[0m')
-          echo "{colored}={$colored}" >> "$GITHUB_OUTPUT"
+          echo "colored=$colored" >> "$GITHUB_OUTPUT"
       - name: Remove ANSI color escape sequences
         uses: marcransome/remove-ansi-colors@v1
         id: remove-ansi-colors

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ jobs:
         id: generate-colored-output
         run: |
           colored=$(printf '\e[0;31mCOLORED\e[0m')
-          echo "::set-output name=colored::$colored"
+          echo "{colored}={$colored}" >> "$GITHUB_ENV"
       - name: Remove ANSI color escape sequences
         uses: marcransome/remove-ansi-colors@v1
         id: remove-ansi-colors

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ jobs:
         id: generate-colored-output
         run: |
           colored=$(printf '\e[0;31mCOLORED\e[0m')
-          echo "{colored}={$colored}" >> "$GITHUB_ENV"
+          echo "{colored}={$colored}" >> "$GITHUB_OUTPUT"
       - name: Remove ANSI color escape sequences
         uses: marcransome/remove-ansi-colors@v1
         id: remove-ansi-colors

--- a/action.yml
+++ b/action.yml
@@ -16,15 +16,10 @@ runs:
   steps:
     - id: ansi-code-removal
       run: |
-        # Strip ANSI color escape sequences
         uncolored="$(echo "${{ inputs.colored }}" | perl -pe 's/\e\[[0-9;]*m//g')"
+        eof=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
 
-        # Replace line feed, carriage return, and percent sign with URL encoding
-        # equivalents; will be substituted correctly in subsequent workflow steps
-        # See: https://github.community/t/set-output-truncates-multiline-strings/16852/5
-        uncolored="${uncolored//'%'/'%25'}"
-        uncolored="${uncolored//$'\n'/'%0A'}"
-        uncolored="${uncolored//$'\r'/'%0D'}"
-
-        echo "uncolored=$uncolored" >> "$GITHUB_OUTPUT"
+        echo "uncolored<<$eof" >> "$GITHUB_OUTPUT"
+        echo "$uncolored" >> "$GITHUB_OUTPUT"
+        echo "$eof" >> "$GITHUB_OUTPUT"
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -26,5 +26,5 @@ runs:
         uncolored="${uncolored//$'\n'/'%0A'}"
         uncolored="${uncolored//$'\r'/'%0D'}"
 
-        echo "{uncolored}={$uncolored}" >> "$GITHUB_ENV"
+        echo "{uncolored}={$uncolored}" >> "$GITHUB_OUTPUT"
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -26,5 +26,5 @@ runs:
         uncolored="${uncolored//$'\n'/'%0A'}"
         uncolored="${uncolored//$'\r'/'%0D'}"
 
-        echo "::set-output name=uncolored::$(echo "$uncolored")"
+        echo "{uncolored}={$uncolored}" >> "$GITHUB_ENV"
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -26,5 +26,5 @@ runs:
         uncolored="${uncolored//$'\n'/'%0A'}"
         uncolored="${uncolored//$'\r'/'%0D'}"
 
-        echo "{uncolored}={$uncolored}" >> "$GITHUB_OUTPUT"
+        echo "uncolored=$uncolored" >> "$GITHUB_OUTPUT"
       shell: bash


### PR DESCRIPTION
This change deprecates the `set-output` command based on the [GitHub Actions: Deprecating save-state and set-output commands](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) post.